### PR TITLE
Adicionar link para feeds

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,6 +6,10 @@
   <title>{{ .Title }}</title>
   <link rel="stylesheet" href="https://cdn.simplecss.org/simple.css">
   <link rel="icon" href="/images/favicon.png">
+  {{ with .OutputFormats.Get "rss" -}}
+      {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+  {{ end }}
+
 
   <meta name="fediverse:creator" content="@gmgall@ursal.zone" />
   <!-- Open Graph -->


### PR DESCRIPTION
Os blogs criados com o modelo geram o feed RSS no endereço canônico do Hugo, mas a falta do link faz com que os leitores de RSS tenham dificuldade em encontrar o feed, sendo necessário informar o link completo, por ex.: https://crieaporradeum.blog/posts/index.xml